### PR TITLE
Version 0.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ results
 
 npm-debug.log
 node_modules
+coverage.html

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
-gulp-cache  ![status](https://secure.travis-ci.org/jgable/gulp-cache.png?branch=master)
+gulp-cache  [![status](https://travis-ci.org/jgable/gulp-cache.png?branch=master)](https://travis-ci.org/jgable/gulp-cache)
 ==========
 
 A temp file based caching proxy task for Gulp.
 
-### Example
+## Usage
 
 ```javascript
+var gulp = require('gulp');
+var jshint = require('gulp-jshint');
+var cache = require('gulp-cache');
+
 gulp.task('lint', function() {
   gulp.src('./lib/*.js')
-    .pipe(cache.proxy({
-      task: jshint('.jshintrc'),
+    .pipe(cache(jshint('.jshintrc'), {
       key: makeHashKey,
+      // What on the result indicates it was successful
       success: function (jshintedFile) {
         return jshintedFile.jshint.success;
       },
@@ -33,25 +37,40 @@ function makeHashKey(file) {
 }
 ```
 
-### License
+## Options
+
+#### Key
+
+> [Optional] What to use to determine the uniqueness of an input file for this task.
+
+- Can return a string or a promise that resolves to a string.  Optionally, can accept a callback parameter for idiomatic node style asynchronous operations.  
+
+- The result of this method is converted to a unique MD5 hash automatically; no need to do this yourself.
+
+- Defaults to `file.contents` if a Buffer, or `undefined` if a Stream.
+
+#### Success
+
+> [Optional] How to determine if the resulting file was successful.
+
+- Must return a truthy value that is used to determine whether to cache the result of the task.
+
+- Defaults to true, so any task results will be cached.
+
+#### Value
+
+> [Optional] What to store as the cached result of the task.
+
+- Can be a function that returns an Object or a promise that resolves to an Object.  Optionally, can accept a callback for idiomatic node style asynchronous operations.
+
+- Can also be set to a string that will be picked (using `_.pick`) of the task result file.
+
+- The result of this method is run through `JSON.stringify` and stored in a temp file for later retrieval.
+
+- Defaults to `'contents'` which will grab the resulting file.contents and store them as a string.
+
+## License
 
 The MIT License (MIT)
 
-Copyright (c) 2014 Jacob Gable
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+Copyright (c) 2014 [Jacob Gable](http://jacobgable.com)

--- a/index.js
+++ b/index.js
@@ -12,44 +12,50 @@ var fileCache = new Cache({
 
 var defaultOptions = {
     fileCache: fileCache,
-    key: _.noop,
-    success: _.noop,
-    value: _.noop
+    name: 'default',
+    key: function (file) {
+        if (file.isBuffer()) {
+            return file.contents.toString('utf8');
+        }
+
+        return undefined;
+    },
+    success: true,
+    value: 'contents'
 };
 
-var cacheTask = {
-    proxy: function (name, opts) {
-        // Check if name was not passed, use default
-        if (_.isObject(name)) {
-            opts = name;
-            name = 'default';
-        }
+var cacheTask = function (task, opts) {
+    var self = this;
 
-        var self = this;
-
-        // Make sure we have some sane defaults
-        opts = _.defaults(opts || {}, defaultOptions);
-        
-        // Check for required task option
-        if (!opts.task) {
-            throw new PluginError('gulp-cache', 'Must pass a task to ' + name + ' cache.proxy');
-        }
-
-        // Pass through the file and cb to _processFile along with the opts
-        return map(function (file, cb) {
-            var taskProxy = new TaskProxy({
-                name: name,
-                file: file,
-                opts: opts
-            });
-
-            taskProxy.processFile().then(function (result) {
-                cb(null, result);
-            }).catch(function (err) {
-                cb(new PluginError('gulp-cache', err));
-            });
-        });
+    // Check for required task option
+    if (!task) {
+        throw new PluginError('gulp-cache', 'Must pass a task to cache()');
     }
+
+    // Check if this task participates in the cacheable contract
+    if (task.cacheable) {
+        // Use the cacheable options, but allow the user to override them
+        opts = _.extend({}, task.cacheable, opts);
+    }
+
+    // Make sure we have some sane defaults
+    opts = _.defaults(opts || {}, defaultOptions);
+
+    return map(function (file, cb) {
+        // Create a TaskProxy object and start up processFile().
+
+        var taskProxy = new TaskProxy({
+            task: task,
+            file: file,
+            opts: opts
+        });
+
+        taskProxy.processFile().then(function (result) {
+            cb(null, result);
+        }).catch(function (err) {
+            cb(new PluginError('gulp-cache', err));
+        });
+    });
 };
 
 cacheTask.fileCache = fileCache;

--- a/lib/TaskProxy.js
+++ b/lib/TaskProxy.js
@@ -6,7 +6,7 @@ var crypto = require('crypto'),
     PluginError = require('gulp-util').PluginError;
 
 var TaskProxy = function (opts) {
-    _.extend(this, _.pick(opts, 'file', 'name', 'opts'));
+    _.extend(this, _.pick(opts, 'task', 'file', 'opts'));
 };
 
 _.extend(TaskProxy.prototype, {
@@ -40,6 +40,10 @@ _.extend(TaskProxy.prototype, {
         }
 
         return Promise.resolve(getKey(this.file)).then(function (key) {
+            if (!key) {
+                return key;
+            }
+
             return makeHash(key);
         });
     },
@@ -48,9 +52,17 @@ _.extend(TaskProxy.prototype, {
         var self = this;
 
         return this._getFileKey().then(function (key) {
+            // If no key returned, bug out early
+            if (!key) {
+                return {
+                    key: key,
+                    value: null
+                };
+            }
+
             var getCached = Promise.promisify(self.opts.fileCache.getCached, self.opts.fileCache);
 
-            return getCached(self.name, key).then(function (cached) {
+            return getCached(self.opts.name, key).then(function (cached) {
                 if (!cached) {
                     return {
                         key: key,
@@ -64,6 +76,11 @@ _.extend(TaskProxy.prototype, {
                     parsedContents = JSON.parse(cached.contents);
                 } catch (e) {
                     parsedContents = { cached: cached.contents };
+                }
+
+                // Vinyl will only allow setting the contents to a buffer or stream
+                if (parsedContents.contents) {
+                    parsedContents.contents = new Buffer(parsedContents.contents);
                 }
 
                 return {
@@ -80,10 +97,10 @@ _.extend(TaskProxy.prototype, {
         return self._runProxiedTask().then(function (result) {
             // If this wasn't a success, continue to next task
             // TODO: Should this also offer an async option?
-            if (!self.opts.success(result)) {
+            if (self.opts.success !== true && !self.opts.success(result)) {
                 return self.file;
             }
-            
+
             return self._storeCachedResult(cachedKey, result).then(function () {
                 return result;
             });
@@ -96,17 +113,17 @@ _.extend(TaskProxy.prototype, {
 
         // Wait for data
         // TODO: Can tasks emit multiple data?
-        this.opts.task.once('data', function (datum) {
+        this.task.once('data', function (datum) {
             def.resolve(datum);
         });
 
-        this.opts.task.once('error', function (err) {
+        this.task.once('error', function (err) {
             def.reject(err);
         });
 
         // Run through the other task and grab output (or error)
         // Not sure if a _.defer is necessary here
-        self.opts.task.write(self.file);
+        self.task.write(self.file);
         
         return def.promise;
     },
@@ -117,6 +134,10 @@ _.extend(TaskProxy.prototype, {
         var getValue = this.opts.value;
 
         if (!_.isFunction(getValue)) {
+            if (_.isString(getValue)) {
+                getValue = _.pick(result, getValue);
+            }
+
             return Promise.resolve(getValue);
         } else if (getValue.length === 2) {
             // Promisify if passed a node style function
@@ -129,6 +150,11 @@ _.extend(TaskProxy.prototype, {
     _storeCachedResult: function (key, result) {
         var self = this;
 
+        // If we didn't have a cachedKey, skip caching result
+        if (!key) {
+            return Promise.resolve(result);
+        }
+
         return this._getValueFromResult(result).then(function (value) {
             var val = value,
                 addCached = Promise.promisify(self.opts.fileCache.addCached, self.opts.fileCache);
@@ -137,7 +163,7 @@ _.extend(TaskProxy.prototype, {
                 val = JSON.stringify(value, null, 2);
             }
 
-            return addCached(self.name, key, val);
+            return addCached(self.opts.name, key, val);
         });
     }
 });

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "gulp-cache",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "A cache proxy task for Gulp",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/jshint/bin/jshint **/*.js && ./node_modules/mocha/bin/mocha -R spec"
+    "test": "./node_modules/jshint/bin/jshint **/*.js && ./node_modules/mocha/bin/mocha -R spec",
+    "coverage": "./node_modules/jshint/bin/jshint **/*.js && ./node_modules/mocha/bin/mocha --require blanket -R html-cov > coverage.html && open coverage.html"
   },
   "repository": {
     "type": "git",
@@ -30,5 +31,11 @@
     "lodash-node": "~2.4.1",
     "bluebird": "~0.11.6-0",
     "map-stream": "~0.1.0"
+  },
+  "config": {
+    "blanket": {
+      "pattern": ["index.js", "/lib/TaskProxy.js"],
+      "data-cover-never": "node_modules"
+    }
   }
 }

--- a/test/main.js
+++ b/test/main.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var PassThrough = require('stream').PassThrough,
+    _ = require('lodash-node'),
     should = require('should'),
     sinon = require('sinon'),
     map = require('map-stream'),
@@ -23,7 +24,15 @@ describe('gulp-cache', function () {
         }),
         fakeTask = map(fakeFileHandler);
 
-        cache.fileCache.clear('test', done);
+        cache.fileCache.clear('default', done);
+    });
+
+    it('throws an error if no task is passed', function () {
+        var shouldThrow = function () {
+            var proxied = cache();
+        };
+
+        shouldThrow.should.throw();
     });
 
     describe('in streaming mode', function () {
@@ -35,16 +44,12 @@ describe('gulp-cache', function () {
                 });
 
             // Create a proxied plugin stream
-            var proxied = cache.proxy('test', {
-                task: fakeTask,
+            var proxied = cache(fakeTask, {
                 key: function (file, cb) {
                     // For testing async key generation
                     setTimeout(function () {
                         cb(null, '123');
                     }, 1);
-                },
-                success: function () {
-                    return true;
                 },
                 value: function (file, cb) {
                     // For testing async value generation
@@ -94,24 +99,96 @@ describe('gulp-cache', function () {
                 });
             });
         });
+
+        it('cannot set a default key for files', function (done) {
+            // create the fake file
+            var fakeStream = new PassThrough(),
+                fakeFile = new gutil.File({
+                    contents: fakeStream
+                });
+
+            // Create a proxied plugin stream
+            var proxied = cache(fakeTask, {
+                value: function (file, cb) {
+                    // For testing async value generation
+                    setTimeout(function () {
+                        cb(null, {
+                            ran: file.ran,
+                            cached: true
+                        });
+                    }, 1);
+                }
+            });
+
+            // write the fake file to it
+            proxied.write(fakeFile);
+
+            // wait for the file to come back out
+            proxied.once('data', function (file) {
+
+                // Check it assigned the proxied task result
+                file.ran.should.equal(true);
+                should.not.exist(file.cached);
+
+                // Check the original task was called
+                fakeFileHandler.called.should.equal(true);
+
+                // Reset for the second run through
+                fakeFileHandler.reset();
+
+                // Write the same file again
+                proxied.write(fakeFile);
+
+                proxied.once('data', function (secondFile) {
+                    // Cached value should not have been applied
+                    secondFile.ran.should.equal(true);
+                    should.not.exist(secondFile.cached);
+
+                    // Should have called the original task
+                    fakeFileHandler.called.should.equal(true);
+
+                    done();
+                });
+            });
+        });
     });
 
     describe('in buffered mode', function () {
-        it('can proxy a task', function (done) {
+        it('only caches successful tasks', function (done) {
             // create the fake file
             var fakeFile = new gutil.File({
                     contents: new Buffer('abufferwiththiscontent')
                 });
 
             // Create a proxied plugin stream
-            var proxied = cache.proxy('test', {
-                task: fakeTask,
-                key: function (file) {
-                    return file.contents.toString('utf8');
-                },
-                success: function () {
-                    return true;
-                },
+            var valStub = sinon.stub().returns({
+                    ran: true,
+                    cached: true
+                }),
+                proxied = cache(fakeTask, {
+                    success: function () {
+                        return false;
+                    },
+                    value: valStub
+                });
+
+            proxied.write(fakeFile);
+
+            proxied.once('data', function (file) {
+                valStub.called.should.equal(false);
+
+                done();
+            });
+        });
+
+        it('can proxy a task with specific options', function (done) {
+            // create the fake file
+            var fakeFile = new gutil.File({
+                    contents: new Buffer('abufferwiththiscontent')
+                });
+
+            // Create a proxied plugin stream
+            var proxied = cache(fakeTask, {
                 value: function (file) {
                     return {
                         ran: file.ran,
@@ -157,6 +234,218 @@ describe('gulp-cache', function () {
 
                     // Should not have called the original task
                     fakeFileHandler.called.should.equal(false);
+
+                    done();
+                });
+            });
+        });
+
+        it('can proxy a task using task.cacheable', function (done) {
+            // create the fake file
+            var fakeFile = new gutil.File({
+                    contents: new Buffer('abufferwiththiscontent')
+                });
+
+            // Let the task define the cacheable aspects.
+            fakeTask.cacheable = {
+                key: sinon.spy(function (file) {
+                    return file.contents.toString('utf8');
+                }),
+                success: sinon.stub().returns(true),
+                value: sinon.stub().returns({
+                    ran: true,
+                    cached: true
+                })
+            };
+
+            var proxied = cache(fakeTask);
+
+            // write the fake file to it
+            proxied.write(fakeFile);
+
+            // wait for the file to come back out
+            proxied.once('data', function (file) {
+                // make sure it came out the same way it went in
+                file.isBuffer().should.equal(true);
+
+                // check the contents are same
+                file.contents.toString('utf8').should.equal('abufferwiththiscontent');
+
+                // Verify the cacheable options were used.
+                fakeTask.cacheable.key.called.should.equal(true);
+                fakeTask.cacheable.success.called.should.equal(true);
+                fakeTask.cacheable.value.called.should.equal(true);
+
+                _.invoke([
+                        fakeTask.cacheable.key, 
+                        fakeTask.cacheable.success, 
+                        fakeTask.cacheable.value,
+                        fakeFileHandler
+                    ], 'reset');
+
+                // Write the same file again, should be cached result
+                proxied.write(fakeFile);
+
+                proxied.once('data', function (secondFile) {
+                    // Cached value should have been applied
+                    secondFile.cached.should.equal(true);
+
+                    fakeTask.cacheable.key.called.should.equal(true);
+                    fakeTask.cacheable.success.called.should.equal(false);
+                    fakeTask.cacheable.value.called.should.equal(false);
+
+                    // Should not have called the original task
+                    fakeFileHandler.called.should.equal(false);
+
+                    done();
+                });
+            });
+        });
+
+        it('can proxy a task using task.cacheable with user overrides', function (done) {
+            // create the fake file
+            var fakeFile = new gutil.File({
+                    contents: new Buffer('abufferwiththiscontent')
+                });
+
+            // Let the task define the cacheable aspects.
+            fakeTask.cacheable = {
+                key: sinon.spy(function (file) {
+                    return file.contents.toString('utf8');
+                }),
+                success: sinon.stub().returns(true),
+                value: sinon.stub().returns({
+                    ran: true,
+                    cached: true
+                })
+            };
+
+            var overriddenValue = sinon.stub().returns({
+                    ran: true,
+                    cached: true,
+                    overridden: true
+                }),
+                proxied = cache(fakeTask, {
+                    value: overriddenValue
+                });
+
+            // write the fake file to it
+            proxied.write(fakeFile);
+
+            // wait for the file to come back out
+            proxied.once('data', function (file) {
+                // make sure it came out the same way it went in
+                file.isBuffer().should.equal(true);
+
+                // check the contents are same
+                file.contents.toString('utf8').should.equal('abufferwiththiscontent');
+
+                // Verify the cacheable options were used.
+                fakeTask.cacheable.key.called.should.equal(true);
+                fakeTask.cacheable.success.called.should.equal(true);
+                fakeTask.cacheable.value.called.should.equal(false);
+                overriddenValue.called.should.equal(true);
+
+                _.invoke([
+                        fakeTask.cacheable.key, 
+                        fakeTask.cacheable.success, 
+                        fakeTask.cacheable.value,
+                        overriddenValue,
+                        fakeFileHandler
+                    ], 'reset');
+
+                // Write the same file again, should be cached result
+                proxied.write(fakeFile);
+
+                proxied.once('data', function (secondFile) {
+                    // Cached value should have been applied
+                    secondFile.cached.should.equal(true);
+                    secondFile.overridden.should.equal(true);
+
+                    fakeTask.cacheable.key.called.should.equal(true);
+                    fakeTask.cacheable.success.called.should.equal(false);
+                    fakeTask.cacheable.value.called.should.equal(false);
+                    overriddenValue.called.should.equal(false);
+
+                    // Should not have called the original task
+                    fakeFileHandler.called.should.equal(false);
+
+                    done();
+                });
+            });
+        });
+
+        it('can be passed just a string for the value', function (done) {
+            // create the fake file
+            var fakeFile = new gutil.File({
+                    contents: new Buffer('abufferwiththiscontent')
+                });
+
+            // Create a proxied plugin stream
+            var proxied = cache(fakeTask, {
+                value: 'ran'
+            });
+
+            // write the fake file to it
+            proxied.write(fakeFile);
+
+            // wait for the file to come back out
+            proxied.once('data', function (file) {
+                // Check it assigned the proxied task result
+                file.ran.should.equal(true);
+
+                // Write the same file again, should be cached result
+                proxied.write(fakeFile);
+
+                proxied.once('data', function (secondFile) {
+                    // Cached value should have been applied
+                    secondFile.ran.should.equal(true);
+
+                    done();
+                });
+            });
+        });
+
+        it('can store changed contents of files', function (done) {
+            // create the fake file
+            var fakeFile = new gutil.File({
+                    contents: new Buffer('abufferwiththiscontent')
+                }),
+                updatedFileHandler = sinon.spy(function (file, cb) {
+                    file.contents = new Buffer('updatedcontent');
+
+                    cb(null, file);
+                });
+
+            fakeTask = map(updatedFileHandler);
+
+            // Create a proxied plugin stream
+            var proxied = cache(fakeTask);
+
+            // write the fake file to it
+            proxied.write(fakeFile);
+
+            // wait for the file to come back out
+            proxied.once('data', function (file) {
+                // Check for updated content
+                file.contents.toString().should.equal('updatedcontent');
+
+                // Check original handler was called
+                updatedFileHandler.called.should.equal(true);
+
+                updatedFileHandler.reset();
+
+                // Write the same file again, should be cached result
+                proxied.write(new gutil.File({
+                    contents: new Buffer('abufferwiththiscontent')
+                }));
+
+                proxied.once('data', function (secondFile) {
+                    // Check for updated content
+                    file.contents.toString().should.equal('updatedcontent');
+
+                    // Check original handler was not called.
+                    updatedFileHandler.called.should.equal(false);
 
                     done();
                 });


### PR DESCRIPTION
- Export function directly instead of .proxy()
- Pass task as first parameter
- Check for cacheable contract from task
- Add tests for coverage of error case and unsuccessful
- Allow just setting success to true
- Allow passing string for value; Closes #4
- Set default key method to use contents or undefined if stream
- Add ability to correctly cache changed contents
- Update README with options
- Bump version for publish
