### PR TITLE
Don't stringify Buffer objects + remove unused vars

### DIFF
--- a/lib/TaskProxy.js
+++ b/lib/TaskProxy.js
@@ -42,8 +42,7 @@ _.extend(TaskProxy.prototype, {
             return crypto.createHash('md5').update(key).digest('hex');
         }
 
-        var getKey = this.opts.key,
-            def;
+        var getKey = this.opts.key;
 
         if (_.isFunction(getKey) && getKey.length === 2) {
             getKey = Promise.promisify(getKey, this.opts);
@@ -58,7 +57,7 @@ _.extend(TaskProxy.prototype, {
         });
     },
 
-    _checkForCachedValue: function (key) {
+    _checkForCachedValue: function () {
         var self = this;
 
         return this._getFileKey().then(function (key) {
@@ -90,7 +89,7 @@ _.extend(TaskProxy.prototype, {
 
                 // Vinyl will only allow setting the contents to a buffer or stream
                 if (parsedContents.contents) {
-                    parsedContents.contents = new Buffer(parsedContents.contents);
+                    parsedContents.contents = new Buffer(parsedContents.contents, 'utf8');
                 }
 
                 return {
@@ -159,8 +158,6 @@ _.extend(TaskProxy.prototype, {
     },
 
     _getValueFromResult: function (result) {
-        var def;
-
         var getValue = this.opts.value;
 
         if (!_.isFunction(getValue)) {
@@ -190,6 +187,12 @@ _.extend(TaskProxy.prototype, {
                 addCached = Promise.promisify(self.opts.fileCache.addCached, self.opts.fileCache);
         
             if (!_.isString(value)) {
+                if (_.isObject(value) && Buffer.isBuffer(value.contents)) {
+                    // Shallow copy so "contents" can be safely modified
+                    val = _.defaults({}, value);
+                    val.contents = val.contents.toString('utf8');
+                }
+
                 val = JSON.stringify(value, null, 2);
             }
 


### PR DESCRIPTION
Before this change, temporary files are written like this:

```
{
    "contents": [
        84,
        128,
        ...
    ]
}
```

Afterwards it will look more like this:

```
{
    "contents": "This is my content"
}
```

The code to change "contents" back into a Buffer already existed but I
added the UTF8 encoding to force a specific encoding instead of letting
it default to UTF8.

The second portion of this commit just removes unused variables.
