### PR TITLE
Changing how File objects are saved and restored

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,10 +2,10 @@
 
 var _ = require('lodash-node'),
     map = require('map-stream'),
-    PluginError = require('gulp-util').PluginError,
+    gutil = require('gulp-util'),
+    PluginError = gutil.PluginError,
     Cache = require('cache-swap'),
-    TaskProxy = require('./lib/TaskProxy'),
-    File = require('vinyl');
+    TaskProxy = require('./lib/TaskProxy');
 
 var fileCache = new Cache({
     cacheDirName: 'gulp-cache'
@@ -26,7 +26,7 @@ var defaultOptions = {
             restored.contents = new Buffer(restored.contents, 'utf8');
         }
 
-        return new File(restored);
+        return new gutil.File(restored);
     },
     success: true,
     value: function (file) {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "cache-swap": "0.0.6",
     "lodash-node": "~2.4.1",
     "bluebird": "~1.0.0",
-    "map-stream": "~0.1.0",
-    "vinyl": "*"
+    "map-stream": "~0.1.0"
   },
   "config": {
     "blanket": {


### PR DESCRIPTION
Before the _.clone would copy an object without a `contents` property but
it did have `_contents`.  This didn't work well at all when it was
restored, especially with gulp-concat.

This patch will restore actual File objects.

Also removed an unused variable and will now produce an error when
encountering a stream.

THIS PATCH BREAKS TESTS!  It works fine for me in real life, but I
don't understand the test system well enough to know how I broke the
tests.
