### PR TITLE
Use through2 instead of map-stream

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -42,7 +42,6 @@
     "supernew": false,
     "undef": true,
     "validthis": false,
-    "smarttabs": true,
     "proto": false,
     "onecase": false,
     "nonstandard": false,
@@ -56,16 +55,13 @@
     "newcap": false,
     "noempty": false,
     "nonew": false,
-    "nomen": false,
-    "onevar": false,
     "plusplus": false,
-    "sub": false,
-    "trailing": false,
     "indent": 4,
-    "white": true,
 
     "maxparams": 5,
     "maxdepth": 3,
     "maxstatements": 30,
-    "maxcomplexity": 8
+    "maxcomplexity": 8,
+
+    "-W079": false
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
+sudo: false
 language: node_js
 node_js:
+  - iojs
+  - "0.12"
   - "0.10"
-  - "0.11"

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var fs = require('fs'),
     _ = require('lodash-node'),
-    map = require('map-stream'),
+    through = require('through2'),
     gutil = require('gulp-util'),
     PluginError = gutil.PluginError,
     Cache = require('cache-swap'),
@@ -66,7 +66,7 @@ var cacheTask = function (task, opts) {
     // Make sure we have some sane defaults
     opts = _.defaults(opts || {}, cacheTask.defaultOptions);
 
-    return map(function (file, cb) {
+    return through.obj(function (file, enc, cb) {
         // Indicate clearly that we do not support Streams
         if (file.isStream()) {
             cb(new PluginError('gulp-cache', 'Can not operate on stream sources'));
@@ -92,7 +92,7 @@ var cacheTask = function (task, opts) {
 cacheTask.clear = function (opts) {
     opts = _.defaults(opts || {}, cacheTask.defaultOptions);
 
-    return map(function (file, cb) {
+    return through.obj(function (file, enc, cb) {
         // Indicate clearly that we do not support Streams
         if (file.isStream()) {
             cb(new PluginError('gulp-cache', 'Can not operate on stream sources'));

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cache-swap": "0.1.0",
     "gulp-util": "^3.0.0",
     "lodash-node": "~2.4.1",
-    "map-stream": "~0.1.0"
+    "through2": "^0.6.3"
   },
   "config": {
     "blanket": {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,9 @@
   "name": "gulp-cache",
   "version": "0.2.4",
   "description": "A cache proxy task for Gulp",
-  "main": "index.js",
   "scripts": {
-    "test": "./node_modules/jshint/bin/jshint **/*.js && ./node_modules/mocha/bin/mocha -R spec",
-    "coverage": "./node_modules/jshint/bin/jshint **/*.js && ./node_modules/mocha/bin/mocha --require blanket -R html-cov > coverage.html && open coverage.html"
+    "test": "jshint **/*.js && mocha",
+    "coverage": "jshint **/*.js && mocha --require blanket -R html-cov > coverage.html && open coverage.html"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,18 +19,18 @@
   "bugs": {
     "url": "https://github.com/jgable/gulp-cache/issues"
   },
-  "devDependencies": {
-    "should": "~2.1.1",
-    "mocha": "~1.17.0",
-    "jshint": "~2.4.1",
-    "sinon": "~1.7.3"
-  },
   "dependencies": {
     "bluebird": "^2.2.2",
-    "cache-swap": "0.1.0",
+    "cache-swap": "^0.1.1",
     "gulp-util": "^3.0.0",
-    "lodash-node": "~2.4.1",
+    "lodash-node": "^3.2.0",
     "through2": "^0.6.3"
+  },
+  "devDependencies": {
+    "should": "^5.0.0",
+    "mocha": "^2.1.0",
+    "jshint": "^2.6.0",
+    "sinon": "^1.12.2"
   },
   "config": {
     "blanket": {

--- a/test/main.js
+++ b/test/main.js
@@ -6,7 +6,7 @@ var path = require('path'),
     _ = require('lodash-node'),
     should = require('should'),
     sinon = require('sinon'),
-    map = require('map-stream'),
+    through = require('through2'),
     gutil = require('gulp-util');
 
 var cache = require('../index');
@@ -22,7 +22,7 @@ describe('gulp-cache', function () {
         sandbox = sinon.sandbox.create();
 
         // Spy on the fakeFileHandler to check if it gets called later
-        fakeFileHandler = sandbox.spy(function (file, cb) {
+        fakeFileHandler = sandbox.spy(function (file, enc, cb) {
             file.ran = true;
 
             if (Buffer.isBuffer(file.contents)) {
@@ -31,7 +31,7 @@ describe('gulp-cache', function () {
             
             cb(null, file);
         });
-        fakeTask = map(fakeFileHandler);
+        fakeTask = through.obj(fakeFileHandler);
 
         cache.fileCache.clear('default', done);
     });
@@ -429,13 +429,13 @@ describe('gulp-cache', function () {
             var fakeFile = new gutil.File({
                     contents: new Buffer('abufferwiththiscontent')
                 }),
-                updatedFileHandler = sandbox.spy(function (file, cb) {
+                updatedFileHandler = sandbox.spy(function (file, enc, cb) {
                     file.contents = new Buffer('updatedcontent');
 
                     cb(null, file);
                 });
 
-            fakeTask = map(updatedFileHandler);
+            fakeTask = through.obj(updatedFileHandler);
 
             // Create a proxied plugin stream
             var proxied = cache(fakeTask);
@@ -476,7 +476,7 @@ describe('gulp-cache', function () {
                         contents: new Buffer('Test File ' + i)
                     });
                 }),
-                fakeTask = map(function (file, cb) {
+                fakeTask = through.obj(function (file, enc, cb) {
                     setTimeout(function () {
                         file.contents = new Buffer(file.contents.toString() + ' updated');
 
@@ -513,13 +513,13 @@ describe('gulp-cache', function () {
                     path: filePath,
                     contents: new Buffer('abufferwiththiscontent')
                 }),
-                updatedFileHandler = sandbox.spy(function (file, cb) {
+                updatedFileHandler = sandbox.spy(function (file, enc, cb) {
                     file.contents = new Buffer('updatedcontent');
 
                     cb(null, file);
                 });
 
-            fakeTask = map(updatedFileHandler);
+            fakeTask = through.obj(updatedFileHandler);
 
             // Create a proxied plugin stream
             var proxied = cache(fakeTask);


### PR DESCRIPTION
* I replaced [map-stream](https://github.com/dominictarr/map-stream) with [through2](https://github.com/rvagg/through2). 
  * through2 uses Stream v2 but map-stream uses v1.
* I updated [should](https://github.com/shouldjs/should.js), [mocha](https://github.com/mochajs/mocha), [jshint](https://github.com/jshint/jshint), [sinon](https://github.com/cjohansen/Sinon.JS), [bluebird](https://github.com/petkaantonov/bluebird) and [lodash-node](https://github.com/lodash/lodash-node).
* I added `sudo: false` to [.travis.yml](https://github.com/jgable/gulp-cache/blob/master/.travis.yml) to enable [container-based infrastructure](http://docs.travis-ci.com/user/workers/container-based-infrastructure/) on Travis CI.
* I added `io.js` and `0.12` to the Node versions that Travis CI tests against. Now Travis CI supports these versions.
* I removed deprecated options from [.jshintrc](https://github.com/jgable/gulp-cache/blob/65b80a511efbf9aade00047db6ae2a9fe9d1baa6/.jshintrc).
