### PR TITLE
updated error messages for null files, added new tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var fileCache = new Cache({
 function defaultKey (file) {
     // Indicate clearly that we do not support Streams and non-file files (e.g., directories)
     if (file.isStream() || file.isNull()) {
-        throw new PluginError('gulp-cache','Can not operate on streams or empty files (e.g., directories)', {showStack: true});
+        throw new PluginError('gulp-cache', 'Can not operate on streams or empty files (e.g., directories)', {showStack: true});
     } else {
         return [pkg.version, file.contents.toString('base64')].join('');
     }
@@ -73,7 +73,7 @@ var cacheTask = function (task, opts) {
     return through.obj(function (file, enc, cb) {
         // Indicate clearly that we do not support Streams and non-file files (e.g., directories)
         if (file.isStream() || file.isNull()) {
-            cb(new PluginError('gulp-cache','Can not operate on streams or empty files (e.g., directories)', {showStack: true}));
+            cb(new PluginError('gulp-cache', 'Can not operate on streams or empty files (e.g., directories)', {showStack: true}));
             return;
         }
 
@@ -99,7 +99,7 @@ cacheTask.clear = function (opts) {
     return through.obj(function (file, enc, cb) {
         // Indicate clearly that we do not support Streams and non-file files (e.g., directories)
         if (file.isStream() || file.isNull()) {
-            cb(new PluginError('gulp-cache','Can not operate on streams or empty files (e.g., directories)', {showStack: true}));
+            cb(new PluginError('gulp-cache', 'Can not operate on streams or empty files (e.g., directories)', {showStack: true}));
             return;
         }
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,13 @@ var fileCache = new Cache({
 });
 
 function defaultKey (file) {
-    return [pkg.version, file.contents.toString('base64')].join('');
+    // Indicate clearly that we do not support Streams and non-file files (e.g., directories)
+    if (file.isStream() || file.isNull()) {
+        throw new PluginError('gulp-cache', 
+            'Can not operate on streams or empty files (e.g., directories)', {showStack: true});
+        return;
+    } else 
+        return [pkg.version, file.contents.toString('base64')].join('');
 }
 
 var defaultOptions = {
@@ -66,9 +72,10 @@ var cacheTask = function (task, opts) {
     opts = objectAssign({}, cacheTask.defaultOptions, opts);
 
     return through.obj(function (file, enc, cb) {
-        // Indicate clearly that we do not support Streams
-        if (file.isStream()) {
-            cb(new PluginError('gulp-cache', 'Cannot operate on stream sources'));
+        // Indicate clearly that we do not support Streams and non-file files (e.g., directories)
+        if (file.isStream() || file.isNull()) {
+            cb(new PluginError('gulp-cache', 
+                'Can not operate on streams or empty files (e.g., directories)', {showStack: true}));
             return;
         }
 
@@ -92,9 +99,10 @@ cacheTask.clear = function (opts) {
     opts = objectAssign({}, cacheTask.defaultOptions, opts);
 
     return through.obj(function (file, enc, cb) {
-        // Indicate clearly that we do not support Streams
-        if (file.isStream()) {
-            cb(new PluginError('gulp-cache', 'Can not operate on stream sources'));
+        // Indicate clearly that we do not support Streams and non-file files (e.g., directories)
+        if (file.isStream() || file.isNull()) {
+            cb(new PluginError('gulp-cache', 
+                'Can not operate on streams or empty files (e.g., directories)', {showStack: true}));
             return;
         }
 

--- a/index.js
+++ b/index.js
@@ -16,11 +16,10 @@ var fileCache = new Cache({
 function defaultKey (file) {
     // Indicate clearly that we do not support Streams and non-file files (e.g., directories)
     if (file.isStream() || file.isNull()) {
-        throw new PluginError('gulp-cache', 
-            'Can not operate on streams or empty files (e.g., directories)', {showStack: true});
-        return;
-    } else 
+        throw new PluginError('gulp-cache','Can not operate on streams or empty files (e.g., directories)', {showStack: true});
+    } else {
         return [pkg.version, file.contents.toString('base64')].join('');
+    }
 }
 
 var defaultOptions = {
@@ -74,8 +73,7 @@ var cacheTask = function (task, opts) {
     return through.obj(function (file, enc, cb) {
         // Indicate clearly that we do not support Streams and non-file files (e.g., directories)
         if (file.isStream() || file.isNull()) {
-            cb(new PluginError('gulp-cache', 
-                'Can not operate on streams or empty files (e.g., directories)', {showStack: true}));
+            cb(new PluginError('gulp-cache','Can not operate on streams or empty files (e.g., directories)', {showStack: true}));
             return;
         }
 
@@ -101,8 +99,7 @@ cacheTask.clear = function (opts) {
     return through.obj(function (file, enc, cb) {
         // Indicate clearly that we do not support Streams and non-file files (e.g., directories)
         if (file.isStream() || file.isNull()) {
-            cb(new PluginError('gulp-cache', 
-                'Can not operate on streams or empty files (e.g., directories)', {showStack: true}));
+            cb(new PluginError('gulp-cache','Can not operate on streams or empty files (e.g., directories)', {showStack: true}));
             return;
         }
 

--- a/test/main.js
+++ b/test/main.js
@@ -62,7 +62,7 @@ describe('gulp-cache', function() {
         });
         describe('check directory path results in empty File', function() {
             it('file contents should not exist', function(done) {
-                var file = new File("../");
+                var file = new File('../');
                 should.not.exist(file.contents);
                 done();
             });

--- a/test/main.js
+++ b/test/main.js
@@ -90,7 +90,7 @@ describe('gulp-cache', function() {
             done();
         });
         it('passing a directory path should create a file without contents', function(done) {
-            var file = new File("../");
+            var file = new File('../');
             should.not.exist(file.contents);
             done();
         });


### PR DESCRIPTION
Hey! It looks like a change (19553fe0e3a202ee09d61c86e3ad03c7f79686da) in gulp-cache exposed a largely ignored problem Google's Web Starter Kit (google/web-starter-kit#636 is the fix and google/web-starter-kit#579 is one of the variants of the problem).  Doesn't seem to be a problem with gulp-cache, but the problem is definitely a bit nasty to track down, it's probably worth calling out errors explicitly when users send things besides buffered files to gulp-cache.  And I swapped in a few more tests just to keep that part of the file.isNull() pie clean.  Let me know if you have any questions!