### PR TITLE
fix(TaskProxy): Bluebird usage

### DIFF
--- a/lib/TaskProxy.js
+++ b/lib/TaskProxy.js
@@ -42,10 +42,9 @@ objectAssign(TaskProxy.prototype, {
     var self = this;
 
     return this._getFileKey().then(function(cachedKey) {
-      var removeCached = Bluebird.promisify(
-        self.opts.fileCache.removeCached,
-        self.opts.fileCache
-      );
+      var removeCached = Bluebird.promisify(self.opts.fileCache.removeCached, {
+        context: self.opts.fileCache
+      });
 
       return removeCached(self.opts.name, cachedKey);
     });


### PR DESCRIPTION
`promisify` was using the wrong argument syntax.
Fixing this also fixes the `cache.clear()` method - previously it
returned `undefined` errors.

:LINK: http://bluebirdjs.com/docs/api/promise.promisify.html