### PR TITLE
Changed default cache behavior to also use file path

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var VERSION = require('./package.json').version;
 var fileCache = new Cache({cacheDirName: 'gulp-cache'});
 
 function defaultKey(file) {
-  return [VERSION, file.path, file.contents.toString('base64')].join('');
+  return [VERSION, file.contents.toString('base64')].join('');
 }
 
 var defaultOptions = {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var VERSION = require('./package.json').version;
 var fileCache = new Cache({cacheDirName: 'gulp-cache'});
 
 function defaultKey(file) {
-  return [VERSION, file.contents.toString('base64')].join('');
+  return [VERSION, file.path, file.contents.toString('base64')].join('');
 }
 
 var defaultOptions = {

--- a/lib/TaskProxy.js
+++ b/lib/TaskProxy.js
@@ -29,7 +29,7 @@ objectAssign(TaskProxy.prototype, {
         // Extend the cached value onto the file, but don't overwrite original path info
         return objectAssign(
           self.file,
-          objectOmit(cached.value, ['cwd', 'path', 'base', 'stat'])
+          objectOmit(cached.value, ['cwd', 'path', 'base', 'stat', 'history'])
         );
       }
 

--- a/test.js
+++ b/test.js
@@ -463,7 +463,7 @@ describe('gulp-cache', function() {
 
         updatedFileHandler.reset();
 
-        // Write a file with same content but different path, should not be cached result
+        // Write a file with same content but different path, should be cached result
         proxied.write(new File({
           path: otherFilePath,
           contents: new Buffer('abufferwiththiscontent')
@@ -474,7 +474,7 @@ describe('gulp-cache', function() {
           should.exist(secondFile.path);
           secondFile.path.should.equal(otherFilePath);
 
-          // Check original handler was called
+          // Check original handler was not called
           updatedFileHandler.called.should.equal(false);
 
           done();

--- a/test.js
+++ b/test.js
@@ -475,7 +475,7 @@ describe('gulp-cache', function() {
           secondFile.path.should.equal(otherFilePath);
 
           // Check original handler was called
-          updatedFileHandler.called.should.equal(true);
+          updatedFileHandler.called.should.equal(false);
 
           done();
         });

--- a/test.js
+++ b/test.js
@@ -433,8 +433,9 @@ describe('gulp-cache', function() {
       proxied.end();
     });
 
-    it('sets the path on cached results', function(done) {
+    it('sets the cache based on file contents and path', function(done) {
       var filePath = path.join(process.cwd(), 'test', 'fixtures', 'in', 'file1.txt');
+      var otherFilePath = path.join(process.cwd(), 'test', 'fixtures', 'in', 'file2.txt');
       var updatedFileHandler = sandbox.spy(function(file, enc, cb) {
         file.contents = new Buffer('updatedcontent');
 
@@ -462,18 +463,19 @@ describe('gulp-cache', function() {
 
         updatedFileHandler.reset();
 
-        // Write the same file again, should be cached result
+        // Write a file with same content but different path, should not be cached result
         proxied.write(new File({
+          path: otherFilePath,
           contents: new Buffer('abufferwiththiscontent')
         }));
 
         proxied.once('data', function(secondFile) {
-          // Check for same file path
+          // Check for different file path
           should.exist(secondFile.path);
-          secondFile.path.should.equal(filePath);
+          secondFile.path.should.equal(otherFilePath);
 
-          // Check original handler was not called.
-          updatedFileHandler.called.should.equal(false);
+          // Check original handler was called
+          updatedFileHandler.called.should.equal(true);
 
           done();
         });


### PR DESCRIPTION
Following this [issue](https://github.com/jgable/gulp-cache/issues/54#issuecomment-197216998), here is the promised PR.

I had to change the last test to match the new behavior.

==============

(@shinnn added)

Fixes https://github.com/jgable/gulp-cache/issues/51
