### PR TITLE
Fixed issue with cache of identical files which change the target pat…

### DIFF
--- a/lib/TaskProxy.js
+++ b/lib/TaskProxy.js
@@ -25,7 +25,7 @@ objectAssign(TaskProxy.prototype, {
     var self = this;
 
     return this._checkForCachedValue().then(function(cached) {
-      // If we found a cached value 
+      // If we found a cached value
       // The path of the cache key should also be identical to the original one when the file path changed inside the task
       if (cached.value && (!cached.value.filePathChangedInsideTask || cached.value.originalPath === self.file.path)) {
         // Extend the cached value onto the file, but don't overwrite original path info

--- a/lib/TaskProxy.js
+++ b/lib/TaskProxy.js
@@ -25,8 +25,9 @@ objectAssign(TaskProxy.prototype, {
     var self = this;
 
     return this._checkForCachedValue().then(function(cached) {
-      // If we found a cached value
-      if (cached.value) {
+      // If we found a cached value 
+      // The path of the cache key should also be identical to the original one when the file path changed inside the task
+      if (cached.value && (!cached.value.filePathChangedInsideTask || cached.value.originalPath === self.file.path)) {
         // Extend the cached value onto the file, but don't overwrite original path info
         var file = objectAssign(
           self.file,
@@ -212,6 +213,9 @@ objectAssign(TaskProxy.prototype, {
         if (value.path !== self.originalPath) {
           value.filePathChangedInsideTask = true;
         }
+
+        // Keep track of the original path
+        value.originalPath = self.originalPath;
 
         val = JSON.stringify(value, null, 2);
       } else {

--- a/test.js
+++ b/test.js
@@ -485,8 +485,8 @@ describe('gulp-cache', function() {
     it('sets the cache based on file contents and path and keeps track of file path changes within the task', function(done) {
       var filePath = path.join(process.cwd(), 'test', 'fixtures', 'in', 'file1.txt');
       var otherFilePath = path.join(process.cwd(), 'test', 'fixtures', 'in', 'file2.txt');
-      var outputFilePath = function (path) {
-        return path.replace(/^(.*)\.txt$/i, '$1.txt2');
+      var outputFilePath = function(targetPath) {
+        return targetPath.replace(/^(.*)\.txt$/i, '$1.txt2');
       };
       var updatedFileHandler = sandbox.spy(function(file, enc, cb) {
         file.contents = new Buffer('updatedcontent');
@@ -515,7 +515,7 @@ describe('gulp-cache', function() {
 
         updatedFileHandler.reset();
 
-        // Write same file again and validate cache result
+        // Write another file with the same contents and validate cache result
         proxied.write(new File({
           path: otherFilePath,
           contents: new Buffer('abufferwiththiscontent')
@@ -536,9 +536,9 @@ describe('gulp-cache', function() {
             contents: new Buffer('abufferwiththiscontent')
           }));
 
-          proxied.once('data', function(secondFile) {
+          proxied.once('data', function(thirdFile) {
             // Check it still has the changed output path
-            secondFile.path.should.equal(outputFilePath(otherFilePath));
+            thirdFile.path.should.equal(outputFilePath(otherFilePath));
 
             // Check original handler was not called
             updatedFileHandler.called.should.equal(false);

--- a/test.js
+++ b/test.js
@@ -482,6 +482,73 @@ describe('gulp-cache', function() {
       });
     });
 
+    it('sets the cache based on file contents and path and keeps track of file path changes within the task', function(done) {
+      var filePath = path.join(process.cwd(), 'test', 'fixtures', 'in', 'file1.txt');
+      var otherFilePath = path.join(process.cwd(), 'test', 'fixtures', 'in', 'file2.txt');
+      var outputFilePath = function (path) {
+        return path.replace(/^(.*)\.txt$/i, '$1.txt2');
+      };
+      var updatedFileHandler = sandbox.spy(function(file, enc, cb) {
+        file.contents = new Buffer('updatedcontent');
+        file.path = outputFilePath(file.path); // Change file path
+        cb(null, file);
+      });
+
+      fakeTask = through.obj(updatedFileHandler);
+
+      // Create a proxied plugin stream
+      var proxied = cache(fakeTask);
+
+      // write the fake file to it
+      proxied.write(new File({
+        path: filePath,
+        contents: new Buffer('abufferwiththiscontent')
+      }));
+
+      // wait for the file to come back out
+      proxied.once('data', function(file) {
+        // Check original handler was called
+        updatedFileHandler.called.should.equal(true);
+
+        // Check it still has the changed output path
+        file.path.should.equal(outputFilePath(filePath));
+
+        updatedFileHandler.reset();
+
+        // Write same file again and validate cache result
+        proxied.write(new File({
+          path: otherFilePath,
+          contents: new Buffer('abufferwiththiscontent')
+        }));
+
+        proxied.once('data', function(secondFile) {
+          // Check it still has the changed output path
+          secondFile.path.should.equal(outputFilePath(otherFilePath));
+
+          // Check original handler was called
+          updatedFileHandler.called.should.equal(true);
+
+          updatedFileHandler.reset();
+
+          // Write same file again and validate cache result
+          proxied.write(new File({
+            path: otherFilePath,
+            contents: new Buffer('abufferwiththiscontent')
+          }));
+
+          proxied.once('data', function(secondFile) {
+            // Check it still has the changed output path
+            secondFile.path.should.equal(outputFilePath(otherFilePath));
+
+            // Check original handler was not called
+            updatedFileHandler.called.should.equal(false);
+
+            done();
+          });
+        });
+      });
+    });
+
     it('keeps track of file path changes within the task', function(done) {
       var filePath = path.join(process.cwd(), 'test', 'fixtures', 'in', 'file1.txt');
       var outputFilePath = filePath.replace(/^(.*)\.txt$/i, '$1.txt2');


### PR DESCRIPTION
Fixed issue with cache of identical files which change the target path inside the plugin.

There was a bug in my last commit. This should fix it.


Issue:
file1.txt and file2.txt have identical contents.
* In: file1.xt => out: file1.txt2
* file1.txt2 was added to the stream
* In: file2.txt => out: file2.txt2 
* file1.txt2 was added to the stream (should have been file2.txt2)

Fix:
When the plugin changes the target path it will now use separate cache entries and discard the fact that the contents are equal.

