### PR TITLE
Update cache-swap to suppress the os.tmpDir deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "bluebird": "^3.0.5",
-    "cache-swap": "^0.2.3",
+    "cache-swap": "^0.3.0",
     "gulp-util": "^3.0.7",
     "object-assign": "^4.0.1",
     "object.omit": "^2.0.0",


### PR DESCRIPTION
(node:5358) DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.