### PR TITLE
One-to-many caching is implemented.

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,9 +61,13 @@ var cacheTask = function(task, opts) {
   // Make sure we have some sane defaults
   opts = objectAssign({}, cacheTask.defaultOptions, opts);
 
+  TaskProxy.injectDoneEvent(task);
+
   return new Transform({
     objectMode: true,
     transform: function(file, enc, cb) {
+      var self = this;
+
       if (file.isNull()) {
         cb(null, file);
         return;
@@ -80,7 +84,10 @@ var cacheTask = function(task, opts) {
         opts: opts
       })
       .processFile().then(function(result) {
-        cb(null, result);
+        result.forEach(function(resultFile) {
+          self.push(resultFile);
+        });
+        cb(null);
       }, function(err) {
         cb(new PluginError('gulp-cache', err));
       });

--- a/lib/TaskProxy.js
+++ b/lib/TaskProxy.js
@@ -168,6 +168,7 @@ objectAssign(TaskProxy.prototype, {
   _runProxiedTask: function(cachedKey) {
     var self = this;
 
+    /* eslint no-use-before-define: 0 */
     return new Bluebird(function(resolve, reject) {
       var data = [];
 

--- a/lib/TaskProxy.js
+++ b/lib/TaskProxy.js
@@ -12,7 +12,8 @@ var TaskProxy = function(opts) {
     task: opts.task,
     file: opts.file,
     opts: opts.opts,
-    originalPath: opts.file.path
+    originalPath: opts.file.path,
+    originalBase: opts.file.base
   });
 };
 
@@ -56,7 +57,8 @@ objectAssign(TaskProxy.prototype, {
       var cachedValue = cached.value;
       var cachedValueNotEmpty = Array.isArray(cachedValue) && cachedValue.length;
       var cachedValueHasNormalPaths = cachedValueNotEmpty && cachedValue.every(function(file) {
-        return !file.filePathChangedInsideTask || file.originalPath === self.file.path;
+        return (!file.filePathChangedInsideTask || file.originalPath === self.file.path) &&
+          (!file.fileBaseChangedInsideTask || file.originalBase === self.file.base);
       });
 
       if (cachedValueHasNormalPaths) {
@@ -69,6 +71,10 @@ objectAssign(TaskProxy.prototype, {
           // Restore the file path if it was set
           if (cachedFile.path && cachedFile.filePathChangedInsideTask) {
             file.path = cachedFile.path;
+          }
+          // Restore the file base if it was set
+          if (cachedFile.base && cachedFile.fileBaseChangedInsideTask) {
+            file.base = cachedFile.base;
           }
           return file;
         });
@@ -267,9 +273,15 @@ objectAssign(TaskProxy.prototype, {
           if (value.path !== self.originalPath) {
             value.filePathChangedInsideTask = true;
           }
+          // Check if the task changed the base path
+          if (value.base !== self.originalBase) {
+            value.fileBaseChangedInsideTask = true;
+          }
 
           // Keep track of the original path
           value.originalPath = self.originalPath;
+          // Keep track of the original base
+          value.originalBase = self.originalBase;
           val = value;
         } else {
           val = value;

--- a/lib/TaskProxy.js
+++ b/lib/TaskProxy.js
@@ -16,6 +16,32 @@ var TaskProxy = function(opts) {
   });
 };
 
+TaskProxy.injectDoneEvent = function(task) {
+  if (typeof task._flush !== 'undefined') {
+    var _flush = task._flush;
+
+    task._flush = function(callback) {
+      var self = this;
+
+      _flush.call(function() {
+        callback.apply(undefined, arguments);
+        self.emit('gulp-cache:done');
+      });
+    };
+  } else {
+    var _transform = task._transform;
+
+    task._transform = function(chunk, encoding, callback) {
+      var self = this;
+
+      _transform.call(this, chunk, encoding, function() {
+        callback.apply(undefined, arguments);
+        self.emit('gulp-cache:done');
+      });
+    };
+  }
+};
+
 function makeHash(key) {
   return crypto.createHash('md5').update(key).digest('hex');
 }
@@ -27,17 +53,26 @@ objectAssign(TaskProxy.prototype, {
     return this._checkForCachedValue().then(function(cached) {
       // If we found a cached value
       // The path of the cache key should also be identical to the original one when the file path changed inside the task
-      if (cached.value && (!cached.value.filePathChangedInsideTask || cached.value.originalPath === self.file.path)) {
-        // Extend the cached value onto the file, but don't overwrite original path info
-        var file = objectAssign(
-          self.file,
-          objectOmit(cached.value, ['cwd', 'path', 'base', 'stat', 'history'])
-        );
-        // Restore the file path if it was set
-        if (cached.value.path && cached.value.filePathChangedInsideTask) {
-          file.path = cached.value.path;
-        }
-        return file;
+      var cachedValue = cached.value;
+      var cachedValueNotEmpty = Array.isArray(cachedValue) && cachedValue.length;
+      var cachedValueHasNormalPaths = cachedValueNotEmpty && cachedValue.every(function(file) {
+        return !file.filePathChangedInsideTask || file.originalPath === self.file.path;
+      });
+
+      if (cachedValueHasNormalPaths) {
+        var files = cachedValue.map(function(cachedFile) {
+          // Extend the cached value onto the file, but don't overwrite original path info
+          var file = objectAssign(
+            self.file.clone({contents: false}),
+            objectOmit(cachedFile, ['cwd', 'path', 'base', 'stat', 'history'])
+          );
+          // Restore the file path if it was set
+          if (cachedFile.path && cachedFile.filePathChangedInsideTask) {
+            file.path = cachedFile.path;
+          }
+          return file;
+        });
+        return files;
       }
 
       // Otherwise, run the proxied task
@@ -101,7 +136,9 @@ objectAssign(TaskProxy.prototype, {
         }
 
         if (self.opts.restore) {
-          parsedContents = self.opts.restore(parsedContents);
+          parsedContents = parsedContents.map(function(parsedFile) {
+            return self.opts.restore(parsedFile);
+          });
         }
 
         return {
@@ -115,10 +152,10 @@ objectAssign(TaskProxy.prototype, {
   _runProxiedTaskAndCache: function(cachedKey) {
     var self = this;
 
-    return self._runProxiedTask().then(function(result) {
+    return self._runProxiedTask(cachedKey).then(function(result) {
       // If this wasn't a success, continue to next task
       // TODO: Should this also offer an async option?
-      if (self.opts.success !== true && !self.opts.success(result)) {
+      if (self.opts.success !== true && !result.every(self.opts.success.bind(self.opts))) {
         return result;
       }
 
@@ -128,41 +165,50 @@ objectAssign(TaskProxy.prototype, {
     });
   },
 
-  _runProxiedTask: function() {
+  _runProxiedTask: function(cachedKey) {
     var self = this;
 
     return new Bluebird(function(resolve, reject) {
+      var data = [];
+
       function handleError(err) {
         // TODO: Errors will step on each other here
 
         // Reduce the maxListeners back down
-        self.task.setMaxListeners(self.task._maxListeners - 1);
+        self.task.setMaxListeners(self.task._maxListeners - 2);
 
         reject(err);
       }
 
-      function handleData(datum) {
+      function collectData(datum) {
         // Wait for data (can be out of order, so check for matching file we wrote)
-        if (self.file !== datum) {
+        if (self.file !== datum && self.file._cachedKey !== cachedKey) {
           return;
         }
 
+        data.push(datum);
+      }
+
+      function handleData() {
         // Be good citizens and remove our listeners
         self.task.removeListener('error', handleError);
         self.task.removeListener('data', handleData);
 
         // Reduce the maxListeners back down
-        self.task.setMaxListeners(self.task._maxListeners - 2);
+        self.task.setMaxListeners(self.task._maxListeners - 3);
 
-        resolve(datum);
+        resolve(data);
       }
 
       // Bump up max listeners to prevent memory leak warnings
       var currMaxListeners = self.task._maxListeners || 0;
-      self.task.setMaxListeners(currMaxListeners + 2);
+      self.task.setMaxListeners(currMaxListeners + 3);
 
-      self.task.on('data', handleData);
+      self.task.on('data', collectData);
+      self.task.once('gulp-cache:done', handleData);
       self.task.once('error', handleError);
+
+      self.file._cachedKey = cachedKey;
 
       // Run through the other task and grab output (or error)
       // Not sure if a _.defer is necessary here
@@ -198,31 +244,35 @@ objectAssign(TaskProxy.prototype, {
       return Bluebird.resolve(result);
     }
 
-    return this._getValueFromResult(result).then(function(value) {
-      var val;
-      var addCached = Bluebird.promisify(self.opts.fileCache.addCached.bind(self.opts.fileCache));
+    var addCached = Bluebird.promisify(self.opts.fileCache.addCached.bind(self.opts.fileCache));
 
-      if (typeof value !== 'string') {
-        if (value && typeof value === 'object' && Buffer.isBuffer(value.contents)) {
-          // Shallow copy so "contents" can be safely modified
-          val = objectAssign({}, value);
-          val.contents = val.contents.toString('utf8');
+    return Promise.all(result.map(function(file) {
+      return self._getValueFromResult(file).then(function(value) {
+        var val;
+
+        if (typeof value !== 'string') {
+          if (value && typeof value === 'object' && Buffer.isBuffer(value.contents)) {
+            // Shallow copy so "contents" can be safely modified
+            val = objectAssign({}, value);
+            val.contents = val.contents.toString('utf8');
+          }
+
+          // Check if the task changed the file path
+          if (value.path !== self.originalPath) {
+            value.filePathChangedInsideTask = true;
+          }
+
+          // Keep track of the original path
+          value.originalPath = self.originalPath;
+          val = value;
+        } else {
+          val = value;
         }
 
-        // Check if the task changed the file path
-        if (value.path !== self.originalPath) {
-          value.filePathChangedInsideTask = true;
-        }
-
-        // Keep track of the original path
-        value.originalPath = self.originalPath;
-
-        val = JSON.stringify(value, null, 2);
-      } else {
-        val = value;
-      }
-
-      return addCached(self.opts.name, key, val);
+        return val;
+      });
+    })).then(function(values) {
+      return addCached(self.opts.name, key, JSON.stringify(values, null, 2));
     });
   }
 });

--- a/lib/TaskProxy.js
+++ b/lib/TaskProxy.js
@@ -173,9 +173,13 @@ objectAssign(TaskProxy.prototype, {
 
       function handleError(err) {
         // TODO: Errors will step on each other here
+        // Be good citizens and remove our listeners
+        self.task.removeListener('error', handleError);
+        self.task.removeListener('gulp-cache:done', handleData);
+        self.task.removeListener('data', collectData);
 
         // Reduce the maxListeners back down
-        self.task.setMaxListeners(self.task._maxListeners - 2);
+        self.task.setMaxListeners(self.task._maxListeners - 3);
 
         reject(err);
       }
@@ -192,7 +196,8 @@ objectAssign(TaskProxy.prototype, {
       function handleData() {
         // Be good citizens and remove our listeners
         self.task.removeListener('error', handleError);
-        self.task.removeListener('data', handleData);
+        self.task.removeListener('gulp-cache:done', handleData);
+        self.task.removeListener('data', collectData);
 
         // Reduce the maxListeners back down
         self.task.setMaxListeners(self.task._maxListeners - 3);

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cache"
   ],
   "scripts": {
-    "pretest": "eslint --config @shinnn/node-legacy --rule 'no-underscore-dangle: 0' --rule 'no-warning-comments: 0' index.js lib test.js",
+    "pretest": "eslint --config @shinnn/node-legacy --rule 'no-underscore-dangle: 0' --rule 'no-warning-comments: 0' --rule 'prefer-rest-params: 0' index.js lib test.js",
     "test": "_mocha test.js",
     "coverage": "istanbul cover _mocha test.js"
   },
@@ -32,16 +32,16 @@
     "object.pick": "^1.1.1",
     "readable-stream": "^2.0.4",
     "try-json-parse": "^0.1.1",
-    "vinyl": "^1.1.0"
+    "vinyl": "^2.0.2"
   },
   "devDependencies": {
-    "@shinnn/eslint-config-node-legacy": "^1.0.0",
-    "eslint": "^1.10.2",
+    "@shinnn/eslint-config-node-legacy": "^3.0.0",
+    "eslint": "^3.19.0",
     "istanbul": "^0.4.1",
     "lodash": "^4.1.0",
-    "mocha": "^2.3.4",
-    "should": "^8.2.1",
-    "sinon": "^1.17.2",
+    "mocha": "^3.3.0",
+    "should": "^11.2.1",
+    "sinon": "^2.2.0",
     "through2": "^2.0.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -490,7 +490,8 @@ describe('gulp-cache', function() {
       };
       var updatedFileHandler = sandbox.spy(function(file, enc, cb) {
         file.contents = new Buffer('updatedcontent');
-        file.path = outputFilePath(file.path); // Change file path
+        // Change file path
+        file.path = outputFilePath(file.path);
         cb(null, file);
       });
 
@@ -554,7 +555,8 @@ describe('gulp-cache', function() {
       var outputFilePath = filePath.replace(/^(.*)\.txt$/i, '$1.txt2');
       var updatedFileHandler = sandbox.spy(function(file, enc, cb) {
         file.contents = new Buffer('updatedcontent');
-        file.path = outputFilePath; // Change file path
+        // Change file path
+        file.path = outputFilePath;
         cb(null, file);
       });
 


### PR DESCRIPTION
gulp-plugins may mutate/produce files by few ways:
- By changing `contents` of Vinyl file (currently supported by gulp-cache)
```js
inputFile.contents = new Buffer(...);
```
- By `clone` method (to my mind this way more correct, support is implemented in this PR)
```js
var outputFile = inputFile.clone({ contents: false });
outputFile.contents = new Buffer(...);
```
- Also gulp-plugin can generate new files.
```js
var outputFiles = [
  new Vinyl(...),
  new Vinyl(...),
  ...
];
```
For correct working of last variant with `gulp-cache`, author of plugin should implement support by himself:
```js
var outputFiles = [
  new Vinyl({..., _cachedKey: inputFile._cachedKey}),
  new Vinyl({..., _cachedKey: inputFile._cachedKey}),
  ...
];
```