### PR TITLE
removed deprecated gulp-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "cache-swap": "^0.3.0",
-    "gulp-util": "^3.0.8",
     "object.pick": "^1.3.0",
+    "plugin-error": "^0.1.2",
     "through2": "^2.0.3",
     "vinyl": "^2.1.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { PluginError } from 'gulp-util';
+import PluginError from 'plugin-error';
 import through from 'through2';
 import Cache from 'cache-swap';
 import File from 'vinyl';


### PR DESCRIPTION
This pr replaces the recently deprecated gulp-util package with corresponding dependencies.

For more info see: https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5
https://github.com/gulpjs/gulp-util/issues/143

Thanks!